### PR TITLE
Add printsupport for qt5

### DIFF
--- a/hippo.pro
+++ b/hippo.pro
@@ -13,7 +13,8 @@ lessThan(QT_MAJOR_VERSION, 5) {
 
 } else {
     QT += webkitwidgets \
-          concurrent
+          concurrent \
+          printsupport
 
     INCLUDEPATH  += /usr/include/poppler/qt5
     LIBS         += -lpoppler-qt5


### PR DESCRIPTION
On Qt5 you need to include printsupport in the pro file, or else you get errors about not being able to include QPrinter
